### PR TITLE
feat: Add BusinessConceptKeyPart management to BusinessConcepts page

### DIFF
--- a/DataSettSln/DataSettViewModel/BusinessConceptViewModel.cs
+++ b/DataSettSln/DataSettViewModel/BusinessConceptViewModel.cs
@@ -54,6 +54,29 @@ namespace DataSett.ViewModel
 
         }
 
+        public void AddKeyPartToSelectedConcept(string name, AttributeProperties keyProperties)
+        {
+            if (SelectedBusinessConcept == null) return;
+
+            var keyPart = new BusinessConceptKeyPart
+            {
+                Name = name,
+                KeyProperties = keyProperties,
+                ParentBusinessConcept = SelectedBusinessConcept
+            };
+
+            SelectedBusinessConcept.KeyParts.Add(keyPart);
+            OnPropertyChanged(nameof(SelectedBusinessConcept));
+        }
+
+        public void RemoveKeyPartFromSelectedConcept(BusinessConceptKeyPart keyPart)
+        {
+            if (SelectedBusinessConcept == null) return;
+
+            SelectedBusinessConcept.KeyParts.Remove(keyPart);
+            OnPropertyChanged(nameof(SelectedBusinessConcept));
+        }
+
         public event PropertyChangedEventHandler? PropertyChanged;
 
         protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)

--- a/DataSettSln/DataSettWorkbench/Components/Dialogs/AddBusinessConceptKeyPartDialog.razor
+++ b/DataSettSln/DataSettWorkbench/Components/Dialogs/AddBusinessConceptKeyPartDialog.razor
@@ -1,0 +1,67 @@
+@using DataSett.Metamodel
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">
+            <MudIcon Icon="@Icons.Material.Filled.Add" Class="mr-2" />
+            Add New Key Part
+        </MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudTextField @bind-Value="Name"
+                      Label="Name"
+                      Variant="Variant.Outlined"
+                      Required="true"
+                      RequiredError="Name is required"
+                      Class="mb-4" />
+        <MudTextField @bind-Value="Datatype"
+                      Label="Datatype"
+                      Variant="Variant.Outlined"
+                      Class="mb-4" />
+        <MudNumericField T="int?" @bind-Value="Length"
+                         Label="Length"
+                         Variant="Variant.Outlined"
+                         Class="mb-4" />
+        <MudNumericField T="int?" @bind-Value="Precision"
+                         Label="Precision"
+                         Variant="Variant.Outlined"
+                         Class="mb-4" />
+        <MudCheckBox T="bool?" @bind-Value="IsNullable"
+                     Label="Is Nullable"
+                     Class="mb-4" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Submit">Add</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter]
+    private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    public string Name { get; set; } = string.Empty;
+    public string? Datatype { get; set; }
+    public int? Length { get; set; }
+    public int? Precision { get; set; }
+    public bool? IsNullable { get; set; }
+
+    private void Submit()
+    {
+        if (!string.IsNullOrWhiteSpace(Name))
+        {
+            var properties = new AttributeProperties
+            {
+                Datatype = Datatype,
+                Length = Length,
+                Precision = Precision,
+                IsNullable = IsNullable
+            };
+            MudDialog.Close(DialogResult.Ok(new AddKeyPartResult(Name, properties)));
+        }
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    public record AddKeyPartResult(string Name, AttributeProperties KeyProperties);
+}

--- a/DataSettSln/DataSettWorkbench/Components/Pages/BusinessConcepts.razor
+++ b/DataSettSln/DataSettWorkbench/Components/Pages/BusinessConcepts.razor
@@ -1,8 +1,10 @@
 @page "/businessconcepts"
 @using DataSett.Metamodel
 @using DataSett.ViewModel
+@using DataSettWorkbench.Components.Dialogs
 
 @inject BusinessConceptViewModel ViewModel
+@inject IDialogService DialogService
 
 <PageTitle>Business Concept Management</PageTitle>
 
@@ -14,22 +16,83 @@
 <MudContainer Class="mt-16 px-8" MaxWidth="MaxWidth.False">
     <MudGrid>
 
-        <!-- List showing business concepts-->
+        <!-- DataGrid showing business concepts -->
         <MudItem xs="12" md="4">
-            <MudPaper>
-                <MudList T="string">
-                    @foreach (var businessConcept in ViewModel.BusinessConcepts)
-                    {
-                        <MudListItem T="string" Text="@businessConcept.Name" @onclick="() => ViewModel.SelectedBusinessConcept = businessConcept">
-                        </MudListItem>
-                    }
-                </MudList>
+            <MudPaper Elevation="2" Class="pa-4" Style="height: 600px; overflow-y: auto;">
+                <MudText Typo="Typo.h6" GutterBottom="true">Business Concepts</MudText>
+                @if (ViewModel.BusinessConcepts != null && ViewModel.BusinessConcepts.Any())
+                {
+                    <MudDataGrid T="BusinessConcept"
+                                 Items="@ViewModel.BusinessConcepts"
+                                 SelectedItemChanged="@OnBusinessConceptSelected"
+                                 Hover="true"
+                                 Dense="true">
+                        <Columns>
+                            <PropertyColumn Property="x => x.Name" Title="Name" />
+                            <PropertyColumn Property="x => x.ParentBusinessDomain != null ? x.ParentBusinessDomain.Name : string.Empty"
+                                          Title="Domain" />
+                            <PropertyColumn Property="x => x.KeyParts.Count" Title="Key Parts" />
+                        </Columns>
+                    </MudDataGrid>
+                }
+                else
+                {
+                    <MudText Typo="Typo.subtitle1" Color="Color.Secondary">
+                        No business concepts found. Please load data from a repository path.
+                    </MudText>
+                }
             </MudPaper>
         </MudItem>
 
         <!-- Detail view of selected business concept -->
         <MudItem xs="12" md="8">
+            <MudPaper Elevation="2" Class="pa-4" Style="height: 600px; overflow-y: auto;">
+                @if (ViewModel.SelectedBusinessConcept != null)
+                {
+                    <MudText Typo="Typo.h6" GutterBottom="true">
+                        Key Parts of: @ViewModel.SelectedBusinessConcept.Name
+                    </MudText>
+                    <MudText Typo="Typo.body2" Class="mb-4">
+                        Domain: @(ViewModel.SelectedBusinessConcept.ParentBusinessDomain?.Name ?? "N/A")
+                    </MudText>
 
+                    <MudDataGrid T="BusinessConceptKeyPart"
+                                 Items="@ViewModel.SelectedBusinessConcept.KeyParts"
+                                 Hover="true"
+                                 Dense="true">
+                        <Columns>
+                            <PropertyColumn Property="x => x.Name" Title="Name" />
+                            <PropertyColumn Property="x => x.KeyProperties.Datatype" Title="Datatype" />
+                            <PropertyColumn Property="x => x.KeyProperties.Length" Title="Length" />
+                            <PropertyColumn Property="x => x.KeyProperties.Precision" Title="Precision" />
+                            <PropertyColumn Property="x => x.KeyProperties.IsNullable" Title="Nullable" />
+                            <TemplateColumn>
+                                <CellTemplate>
+                                    <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                                   Size="Size.Small"
+                                                   Color="Color.Error"
+                                                   OnClick="() => RemoveKeyPart(context.Item)" />
+                                </CellTemplate>
+                            </TemplateColumn>
+                        </Columns>
+                    </MudDataGrid>
+
+                    <MudButton Color="Color.Primary"
+                               Variant="Variant.Filled"
+                               StartIcon="@Icons.Material.Filled.Add"
+                               Class="mt-4"
+                               OnClick="OpenAddKeyPartDialog">
+                        Add Key Part
+                    </MudButton>
+                }
+                else
+                {
+                    <MudText Typo="Typo.h6" GutterBottom="true">Key Parts</MudText>
+                    <MudText Typo="Typo.subtitle1" Color="Color.Secondary">
+                        Select a business concept to view and manage its key parts.
+                    </MudText>
+                }
+            </MudPaper>
         </MudItem>
 
     </MudGrid>
@@ -45,6 +108,30 @@
     private void GetData()
     {
         ViewModel.GetBusinessConceptData();
+        StateHasChanged();
+    }
+
+    private void OnBusinessConceptSelected(BusinessConcept? selectedConcept)
+    {
+        ViewModel.SelectedBusinessConcept = selectedConcept;
+        StateHasChanged();
+    }
+
+    private async Task OpenAddKeyPartDialog()
+    {
+        var dialog = await DialogService.ShowAsync<AddBusinessConceptKeyPartDialog>("Add Key Part");
+        var result = await dialog.Result;
+
+        if (result is { Canceled: false, Data: AddBusinessConceptKeyPartDialog.AddKeyPartResult keyPartResult })
+        {
+            ViewModel.AddKeyPartToSelectedConcept(keyPartResult.Name, keyPartResult.KeyProperties);
+            StateHasChanged();
+        }
+    }
+
+    private void RemoveKeyPart(BusinessConceptKeyPart keyPart)
+    {
+        ViewModel.RemoveKeyPartFromSelectedConcept(keyPart);
         StateHasChanged();
     }
 


### PR DESCRIPTION
Closes #36

## Summary
Makes it possible to maintain BusinessConceptKeyPart associations on the BusinessConcepts page.

## Changes
- **Upgraded left panel** — Replaced `MudList` with `MudDataGrid<BusinessConcept>` showing Name, Domain, and Key Parts count columns
- **Added detail panel** — Right side shows selected concept's KeyParts in a `MudDataGrid` with Name, Datatype, Length, Precision, Nullable columns and per-row Remove button
- **New dialog** — `AddBusinessConceptKeyPartDialog.razor` for creating new KeyParts (Name, Datatype, Length, Precision, IsNullable)
- **ViewModel methods** — Added `AddKeyPartToSelectedConcept` and `RemoveKeyPartFromSelectedConcept` to `BusinessConceptViewModel`

## Files Changed
| File | Action |
|------|--------|
| `BusinessConcepts.razor` | Major update — DataGrid, detail panel, dialog integration |
| `BusinessConceptViewModel.cs` | Added KeyPart add/remove methods |
| `AddBusinessConceptKeyPartDialog.razor` | **New file** — dialog for creating KeyParts |

## Implementation Plan

### Problem
The `BusinessConcepts.razor` page only listed business concepts in a simple `MudList`. There was no way to view, add, or remove `BusinessConceptKeyPart` associations. The detail panel (right side) was empty.

### Approach
Follow existing patterns from `BusinessDomains.razor` (MudDataGrid + detail panel) and `AddBusinessConceptDialog.razor` (MudDialog pattern).

### Key Model Relationships
- `BusinessConceptBase.KeyParts` → `IList<BusinessConceptKeyPart>` (1:N)
- `BusinessConceptKeyPart.ParentBusinessConcept` → navigation back to parent (JsonIgnored)
- `BusinessConceptKeyPart` has: `Name`, `KeyProperties` (AttributeProperties with Datatype, Length, Precision, IsNullable, etc.)
- Persistence: KeyParts serialize as part of the BusinessConcept JSON; no separate file

### Implementation Steps
1. **Upgrade BusinessConcepts list to MudDataGrid** — Replace `MudList` with `MudDataGrid<BusinessConcept>` (Name, Parent Domain, KeyParts Count columns)
2. **Add KeyParts detail panel** — Display selected concept info and `MudDataGrid<BusinessConceptKeyPart>` with Remove button per row
3. **Create AddBusinessConceptKeyPartDialog** — New dialog following existing pattern (MudDialog, Cancel/Submit, result record)
4. **Add ViewModel methods** — `AddKeyPartToSelectedConcept` and `RemoveKeyPartFromSelectedConcept`
5. **Wire up Add/Remove in Razor page** — Add button opens dialog, Remove button per-row
6. **Verify persistence** — Confirmed existing save flow (`WriteDataAsync`) handles KeyParts automatically since they're embedded in BusinessConcept JSON

### Notes
- No changes needed to metamodel classes or serialization
- Follows MudBlazor v8 patterns already used in the project
- Build passes cleanly (0 errors, 0 warnings)